### PR TITLE
Kimpanel-IBus and Emojier packages and not enforce Fedora's LNF

### DIFF
--- a/PLASMA/plasma-desktop/plasma-desktop.spec
+++ b/PLASMA/plasma-desktop/plasma-desktop.spec
@@ -10,7 +10,7 @@
 Name:    plasma-desktop
 Summary: Plasma Desktop shell
 Version: 5.25.4
-Release: 1%{?dist}
+Release: 2%{?dist}
 
 License: GPLv2+ and (GPLv2 or GPLv3)
 URL:     https://invent.kde.org/plasma/%{name}
@@ -159,9 +159,6 @@ Requires:       kf5-kirigami2%{?_isa}
 BuildRequires:  qqc2-desktop-style
 Requires:       qqc2-desktop-style%{?_isa}
 
-# for ibus-ui-emojier-plasma
-Recommends: ibus
-
 # Virtual provides for plasma-workspace
 Provides:       plasmashell(desktop) = %{version}-%{release}
 Provides:       plasmashell = %{version}-%{release}
@@ -183,12 +180,27 @@ Conflicts:      kde-l10n < 15.12.3-4
 %description
 %{summary}.
 
+%package        kimpanel-ibus
+Summary:        IBus backend for kimpanel
+Requires:       %{name} = %{version}-%{release}
+%description    kimpanel-ibus
+A backend for the kimpanel panel icon for input methods using the IBus input
+method framework.
+
 %package        kimpanel-scim
 Summary:        SCIM backend for kimpanel
 Requires:       %{name} = %{version}-%{release}
 %description    kimpanel-scim
 A backend for the kimpanel panel icon for input methods using the SCIM input
 method framework.
+
+%package        emojier
+Summary:        Selection window for emoji text input
+Requires:       %{name} = %{version}-%{release}
+Recommends:     ibus
+Recommends:     ibus-uniemoji
+%description    emojier
+%{summary}.
 
 %package        doc
 Summary:        Documentation and user manuals for %{name}
@@ -268,12 +280,9 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/org.kde.knetattach.d
 %{_bindir}/kaccess
 %{_bindir}/knetattach
 %{_bindir}/solid-action-desktop-gen
-%{_bindir}/ibus-ui-emojier-plasma
 %{_bindir}/tastenbrett
 %{_bindir}/krunner-plugininstaller
 %{_kf5_libexecdir}/kauth/kcmdatetimehelper
-%{_libexecdir}/kimpanel-ibus-panel
-%{_libexecdir}/kimpanel-ibus-panel-launcher
 %{_kf5_qmldir}/org/kde/plasma/private
 # TODO: -libs subpkg -- rex
 %{_kf5_qtplugindir}/*.so
@@ -300,7 +309,6 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/org.kde.knetattach.d
 %{_kf5_datadir}/kcmmouse/
 %endif
 %{_datadir}/config.kcfg/*.kcfg
-%{_datadir}/kglobalaccel/org.kde.plasma.emojier.desktop
 %{_datadir}/qlogging-categories5/*.categories
 %{_kf5_datadir}/kconf_update/*
 %{_kf5_datadir}/kcmkeys
@@ -317,21 +325,34 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/org.kde.knetattach.d
 %endif
 %{_kf5_metainfodir}/*.xml
 %{_datadir}/applications/*.desktop
+%exclude %{_datadir}/applications/org.kde.plasma.emojier.desktop
 %{_datadir}/dbus-1/system-services/*.service
 %{_datadir}/polkit-1/actions/org.kde.kcontrol.kcmclock.policy
 %{_sysconfdir}/xdg/autostart/*.desktop
 %{_kf5_datadir}/accounts/providers/kde/
 %{_kf5_datadir}/accounts/services/kde/
 
+%files kimpanel-ibus
+%{_libexecdir}/kimpanel-ibus-panel
+%{_libexecdir}/kimpanel-ibus-panel-launcher
+
 %if 0%{?scim}
 %files kimpanel-scim
 %{_libexecdir}/kimpanel-scim-panel
 %endif
 
+%files emojier
+%{_bindir}/ibus-ui-emojier-plasma
+%{_datadir}/kglobalaccel/org.kde.plasma.emojier.desktop
+%{_datadir}/applications/org.kde.plasma.emojier.desktop
+
 %files doc -f %{name}-doc.lang
 
 
 %changelog
+* Fri Aug 19 2022 Christian Tosta <devel@cpuhouse.com.br> - 5.25.4-2
+- Split IBus and Emojier packages
+
 * Tue Aug 02 2022 Yaroslav Sidlovsky <zawertun@gmail.com> - 5.25.4-1
 - 5.25.4
 

--- a/PLASMA/plasma-workspace/plasma-workspace.spec
+++ b/PLASMA/plasma-workspace/plasma-workspace.spec
@@ -21,7 +21,7 @@
 Name:    plasma-workspace
 Summary: Plasma workspace, applications and applets
 Version: 5.25.4
-Release: 1%{?dist}
+Release: 2%{?dist}
 
 License: GPLv2+
 URL:     https://invent.kde.org/plasma/%{name}
@@ -47,7 +47,7 @@ Source15:       fedora.desktop
 
 # breeze fedora sddm theme components
 # includes f25-based preview (better than breeze or nothing at least)
-Source20:       breeze-fedora-0.2.tar.gz
+Source20:       https://github.com/ZaWertun/fedora-copr-kde5/raw/master/PLASMA/plasma-workspace/breeze-fedora-0.2.tar.gz
 
 ## systemd user service dependencies
 ## (debating whether these be owned here or somewhere better...
@@ -250,7 +250,7 @@ Requires:       iceauth xrdb xprop
 Requires:       kde-settings-plasma
 
 # Default look-and-feel theme
-Requires:       plasma-lookandfeel-fedora = %{version}-%{release}
+Recommends:     plasma-lookandfeel-default >= %{version}-%{release}
 
 Requires:       systemd
 
@@ -281,7 +281,7 @@ Requires:       plasmashell >= %{majmin_ver}
 Obsoletes:      plasma-workspace < 5.4.2-2
 
 # plasmashell provides dbus service org.freedesktop.Notifications
-Provides: desktop-notification-daemon
+Provides: desktop-notification-daemon > 0
 
 # upgrade path, when sddm-breeze was split out
 Obsoletes: plasma-workspace < 5.3.2-8
@@ -379,21 +379,41 @@ Recommends:     qt5-qtvirtualkeyboard
 # org.kde.plasma.workspace.components
 # org.kde.plasma.workspace.keyboardlayout
 Requires:       %{name} = %{version}-%{release}
-# /usr/share/backgrounds/default.png
 %if 0%{?fedora}
-BuildRequires:  desktop-backgrounds-compat
-Requires:       desktop-backgrounds-compat
+Recommends:     sddm-breeze-fedora
 %endif
 %if 0%{?rhel}
-Requires:       system-logos
+Recommends:     system-logos
 %endif
 BuildArch: noarch
 %description -n sddm-breeze
 %{summary}.
 
+%package -n sddm-breeze-fedora
+Summary:        SDDM breeze theme (Fedora variant)
+# upgrade path, when sddm-breeze was split out
+Obsoletes:      plasma-workspace < 5.3.2-8
+Requires:       kf5-plasma >= %{_kf5_version}
+# Background.qml:import QtQuick
+Requires:       qt5-qtquickcontrols
+# on-screen keyboard
+Recommends:     qt5-qtvirtualkeyboard
+# QML imports:
+# org.kde.plasma.workspace.components
+# org.kde.plasma.workspace.keyboardlayout
+Requires:       %{name} = %{version}-%{release}
+# /usr/share/backgrounds/default.png
+%if 0%{?fedora}
+BuildRequires:  desktop-backgrounds-compat
+Requires:       desktop-backgrounds-compat
+%endif
+BuildArch: noarch
+%description -n sddm-breeze-fedora
+%{summary}.
+
 %package -n sddm-wayland-plasma
 Summary:        Plasma Wayland SDDM greeter configuration
-Provides:       sddm-greeter-displayserver
+Provides:       sddm-greeter-displayserver > 0
 Conflicts:      sddm-greeter-displayserver
 Requires:       kwin-wayland >= %{majmin_ver}
 Requires:       maliit-keyboard
@@ -443,6 +463,7 @@ Obsoletes: f22-kde-theme < 22.4
 Obsoletes: f23-kde-theme < 23.1
 Obsoletes: f24-kde-theme < 24.6
 Obsoletes: f24-kde-theme-core < 5.10.5-2
+Provides:  plasma-lookandfeel-default = %{version}-%{release}
 BuildArch: noarch
 %description -n plasma-lookandfeel-fedora
 %{summary}.
@@ -757,8 +778,10 @@ desktop-file-validate %{buildroot}%{_kf5_datadir}/applications/org.kde.{klipper,
 
 %files -n sddm-breeze
 %{_datadir}/sddm/themes/breeze/
+
+%files -n sddm-breeze-fedora
 %{_datadir}/sddm/themes/01-breeze-fedora/
-#%config(noreplace) %{_datadir}/sddm/themes/01-breeze-fedora/theme.conf.user
+#%#config(noreplace) %#{_datadir}/sddm/themes/01-breeze-fedora/theme.conf.user
 
 %files -n sddm-wayland-plasma
 %{_prefix}/lib/sddm/sddm.conf.d/plasma-wayland.conf
@@ -789,6 +812,10 @@ desktop-file-validate %{buildroot}%{_kf5_datadir}/applications/org.kde.{klipper,
 
 
 %changelog
+* Fri Aug 19 2022 Christian Tosta <devel@cpuhouse.com.br> - 5.25.4-2
+- do not hard-enforce use of Fedora's LookAndFeel
+- validated spec file against rpmlint
+
 * Tue Aug 02 2022 Yaroslav Sidlovsky <zawertun@gmail.com> - 5.25.4-1
 - 5.25.4
 


### PR DESCRIPTION
### 98fd5ff: split Kimpanel-IBus and Emojier packages
- fix: The emojier application was installed by the package but shows no glimpses (bugzilla #1855926)
- enhancement: split emojier sub-package (some corporative users can't want it on menu at all)
- enhancement: split Kimpanel IBus back-end sub-package (it's unnecessary for occidental languages)

### fb4f728:  do not hard-enforce use of Fedora's LookAndFeel
- enhancement: Enforcing Fedora artwork is not a friendly with derivative work and hurts collaborative philosophy. So we are
modified the dependencies in a way that not prohibit derivative works nor get rid of Fedora's work.